### PR TITLE
only register sourceSet-specific tasks after KGP is applied

### DIFF
--- a/ktlint-gradle-plugin/src/integrationTest/kotlin/com/rickbusarow/ktlint/SourceSetTest.kt
+++ b/ktlint-gradle-plugin/src/integrationTest/kotlin/com/rickbusarow/ktlint/SourceSetTest.kt
@@ -248,4 +248,36 @@ internal class SourceSetTest : BaseGradleTest {
       """.trimIndent()
     }
   }
+
+  @Test
+  fun `source set tasks are registered if the Kotlin plugin is applied after ktlint`() = test {
+
+    buildFile {
+      """
+      plugins {
+        id("com.rickbusarow.ktlint")
+        kotlin("jvm")
+      }
+      """
+    }
+
+    workingDir
+      .resolve("src/main/kotlin/com/test/File.kt")
+      .kotlin(
+        """
+        package com.test
+
+        class File { }
+
+        """
+      )
+
+    shouldSucceed("ktlintFormat") {
+      task(":ktlintFormatMain")?.outcome shouldBe TaskOutcome.SUCCESS
+
+      output.remove(workingDir.path).noAnsi() shouldInclude """
+        file:///src/main/kotlin/com/test/File.kt:3:12 ✅ standard:no-empty-class-body ═ Unnecessary block ("{}")
+      """.trimIndent()
+    }
+  }
 }

--- a/ktlint-gradle-plugin/src/main/kotlin/com/rickbusarow/ktlint/KtLintPlugin.kt
+++ b/ktlint-gradle-plugin/src/main/kotlin/com/rickbusarow/ktlint/KtLintPlugin.kt
@@ -59,17 +59,10 @@ abstract class KtLintPlugin : Plugin<GradleProject> {
       target.projectDir.resolveInParentOrNull(".editorconfig")
     }
 
-    val sourceSets = getSourceSets(target)
-
-    var rootName = "root"
-    while (sourceSets.containsKey(rootName)) {
-      rootName += "_"
-    }
-
     val rootTaskPair = registerFormatCheckPair(
       target = target,
       taskNameSuffix = "",
-      sourceFileShadowDirectory = target.sourceFileShadowDirectory(rootName),
+      sourceFileShadowDirectory = target.sourceFileShadowDirectory("ktlintRoot"),
       sourceDirectorySet = null,
       editorConfigFile = editorConfigFile,
       configProvider = configProvider
@@ -83,7 +76,7 @@ abstract class KtLintPlugin : Plugin<GradleProject> {
 
         val includedBuildDirs = target.gradle.includedBuilds.map { it.projectDir }
         val subProjectDirs = target.subprojects.mapToSet { it.projectDir }
-        val srcDirs = sourceSets.values.flatMapToSet { it.get().kotlin.srcDirs }
+        val srcDirs = target.getSourceSets().values.flatMapToSet { it.get().kotlin.srcDirs }
         val reg = Regex(""".*\.gradle\.kts$""")
         target.files(
           target.projectDir
@@ -109,16 +102,16 @@ abstract class KtLintPlugin : Plugin<GradleProject> {
     rootTaskPair.second.dependsOn(scriptTaskPair.second)
 
     target.plugins.withId("org.jetbrains.kotlin.jvm") {
-      registerKotlinTasks(target, rootTaskPair, sourceSets, editorConfigFile, configProvider)
+      registerKotlinTasks(target, rootTaskPair, editorConfigFile, configProvider)
     }
     target.plugins.withId("org.jetbrains.kotlin.android") {
-      registerKotlinTasks(target, rootTaskPair, sourceSets, editorConfigFile, configProvider)
+      registerKotlinTasks(target, rootTaskPair, editorConfigFile, configProvider)
     }
     target.plugins.withId("org.jetbrains.kotlin.js") {
-      registerKotlinTasks(target, rootTaskPair, sourceSets, editorConfigFile, configProvider)
+      registerKotlinTasks(target, rootTaskPair, editorConfigFile, configProvider)
     }
     target.plugins.withId("org.jetbrains.kotlin.multiplatform") {
-      registerKotlinTasks(target, rootTaskPair, sourceSets, editorConfigFile, configProvider)
+      registerKotlinTasks(target, rootTaskPair, editorConfigFile, configProvider)
     }
 
     if (target.isRootProject()) {
@@ -129,21 +122,21 @@ abstract class KtLintPlugin : Plugin<GradleProject> {
   private fun registerKotlinTasks(
     target: GradleProject,
     rootTaskPair: Pair<TaskProvider<KtLintFormatTask>, TaskProvider<KtLintCheckTask>>,
-    sourceSets: Map<String, NamedDomainObjectProvider<KotlinSourceSet>>,
     editorConfigFile: Lazy<File?>,
     configProvider: NamedDomainObjectProvider<GradleConfiguration>?
   ) {
 
-    val pairs = sourceSets.map { (sourceSetName, sourceSet) ->
-      registerFormatCheckPair(
-        target = target,
-        taskNameSuffix = sourceSetName.capitalize(),
-        sourceFileShadowDirectory = target.sourceFileShadowDirectory(sourceSetName),
-        sourceDirectorySet = sourceSet.map { it.kotlin.minus(target.fileTree(target.buildDir)) },
-        editorConfigFile = editorConfigFile,
-        configProvider = configProvider
-      )
-    }
+    val pairs = target.getSourceSets()
+      .map { (sourceSetName, sourceSet) ->
+        registerFormatCheckPair(
+          target = target,
+          taskNameSuffix = sourceSetName.capitalize(),
+          sourceFileShadowDirectory = target.sourceFileShadowDirectory(sourceSetName),
+          sourceDirectorySet = sourceSet.map { it.kotlin.minus(target.fileTree(target.buildDir)) },
+          editorConfigFile = editorConfigFile,
+          configProvider = configProvider
+        )
+      }
 
     val formatTasks = pairs.map { it.first }
     val lintTasks = pairs.map { it.second }
@@ -152,10 +145,10 @@ abstract class KtLintPlugin : Plugin<GradleProject> {
     rootTaskPair.second.dependsOn(lintTasks)
   }
 
-  private fun getSourceSets(target: GradleProject): Map<String, NamedDomainObjectProvider<KotlinSourceSet>> {
+  private fun GradleProject.getSourceSets(): Map<String, NamedDomainObjectProvider<KotlinSourceSet>> {
 
     val kotlinExtension = try {
-      val extension = target.extensions.findByName("kotlin")
+      val extension = extensions.findByName("kotlin")
 
       extension as? org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
     } catch (_: ClassNotFoundException) {


### PR DESCRIPTION
Otherwise, there are no sourceSet-specific tasks (like `ktlintFormatMain`) if the ktlint plugin is applied before KGP